### PR TITLE
Get map link from address instead of lat/lng; update "hosted at" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Hosted at: [http://marsbtyne.github.io/nycfridge](http://marsbtyne.github.io/nycfridge)
+Hosted at: [http://marsbtyne.github.io](http://marsbtyne.github.io)
 
 
 ## Available Scripts

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -65,7 +65,7 @@ class Map extends Component {
   }
 
   getMapLink = (fridge) => {
-    return 'https://www.google.com/maps/dir/?api=1&destination='.concat(fridge.lat, ",", fridge.lng)
+    return 'https://www.google.com/maps/place/'.concat(fridge.streetAddress.split(' ').join('+'))
   }
 
   getChecks = (currentFridge) => {

--- a/src/components/UI/FridgeModal.js
+++ b/src/components/UI/FridgeModal.js
@@ -64,8 +64,8 @@ const FridgeModal = (props) => {
     <Button onClick={props.editFridge} label="Edit Fridge" />
   )
 
-  const getMapLink = (lat, lng) => {
-    return 'https://www.google.com/maps/dir/?api=1&destination='.concat(lat, ",", lng)
+  const getMapLink = (address) => {
+    return 'https://www.google.com/maps/place/'.concat(address.split(' ').join('+'))
   }
 
   return (


### PR DESCRIPTION
Hey! Thank you so much for creating this. Not sure if this project is still being maintained or if you're open to contributions, but I found this map super useful when I found it through a Google search.

Most of the Google Maps address link are slightly off when I click on them because of the use of latitude/longitude instead of address. I think this small fix will help with that, but please feel free to reject this PR if not. (FYI, I've unit tested the changes but haven't spun up the repo locally because I didn't want to go through the hassle of setting up an API key lol)

Also, this PR fixes the "hosted at" link in the README to point at the current hosting of the project.